### PR TITLE
feat: [P4PU-519] skipping auth after checking token expiration date

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+BASE_URL=https://dev.cittadini.pagopa.it
+# LOCAL | DEV | UAT
+ENVIRONMENT=LOCAL 
+USERNAME=
+PASSWORD=

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,6 @@ node_modules/
 /playwright/.cache/
 
 .env.local
-
+.env
 auth/
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test": "playwright test"
   },
   "dependencies": {
-    "dotenv": "^16.4.5"
+    "dotenv": "^16.4.5",
+    "jwt-decode": "^4.0.0"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,9 +2,9 @@ import { defineConfig, devices } from '@playwright/test';
 import dotenv from 'dotenv';
 import path from 'path';
 
-const ENV = process.env.NODE_ENV || 'dev';
-console.log(`Running tests on NODE_ENV: ${ENV}`)
-dotenv.config({ path: path.resolve(__dirname, `.env.${ENV}`) })
+dotenv.config({ path: path.resolve(__dirname, '.env')});
+
+console.log(`Running tests on: ${process.env.BASE_URL}; environment: ${process.env.ENVIRONMENT}`);
 
 /**
  * See https://playwright.dev/docs/test-configuration.

--- a/tests/login.setup.ts
+++ b/tests/login.setup.ts
@@ -5,7 +5,7 @@ import path from 'path';
 const authFile = path.join(__dirname, `../${userPath}`);
 
 setup("[E2E-ARC-1]Come Cittadino voglio autenticarmi nell' Area Riservata Cittadino per poter usufruire dei servizi offerti", async ({ page }) => {
-  setup.skip(skipAuth(), 'Non è necessario autenticarsi più volte, sopratutto durante le fasi di sviluppo e debug');
+  setup.skip(await skipAuth(), 'Non è necessario autenticarsi più volte, sopratutto durante le fasi di sviluppo e debug');
   
   const username = process.env?.USERNAME;
 	const password = process.env?.PASSWORD;

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,6 +26,11 @@ fsevents@2.3.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
+jwt-decode@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-4.0.0.tgz#2270352425fd413785b2faf11f6e755c5151bd4b"
+  integrity sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==
+
 playwright-core@1.47.1:
   version "1.47.1"
   resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.47.1.tgz#bb45bdfb0d48412c535501aa3805867282857df8"


### PR DESCRIPTION
### Description
Skipping authentication phase automatically after checking token expiration date
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- skipAuth function improved: comparing token expiration time with local time and skipping authentication accordingly
- deleted .env.dev file
- added .env to .gitignore
- added .env.example file

<!--- Describe your changes in detail -->

### Motivation and context
The goal of this PR is to have a totally automated checking about the needed of authentication to the app. This is possible extracting the expiration time from the jwt token
<!--- Why is this change required? What problem does it solve? -->

### Aggregation level

<!--- Did you write a single reusable test case, or a full test suite?  -->

- [ ] Test case
- [ ] Test suite

### Type of changes

- [ ] Add new test case/suite
- [x] Modify existing test case/suite

### Test Results

- [x] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Did you update secrets accordingly?

- [ ] Yes
  - [ ] `.pu_ux_secrets_template.yaml`
  - [ ] Pipelines' secure file
  - [ ] Confluence
- [x] Not needed
- [ ] No (_please provide further information_)

### Did you update dependencies accordingly?

Run:

- `npm install 'package'`

and check for changes.

- [x] Yes
  - [x] `node_modules`
- [ ] Not needed
- [ ] No (_please provide further information_)

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->