### PR TITLE
feat: [P4PU-495] receipt PDF, E2E test

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -49,6 +49,12 @@ export default defineConfig({
       name: 'firefox',
       use: { ...devices['Desktop Firefox'],
         storageState: './auth/user.json',
+        launchOptions: {
+          firefoxUserPrefs: {
+            // allow pdf on new tab
+            'pdfjs.disabled': false,
+          },
+        }
       },
       dependencies: ['setup'],
     },

--- a/tests/receipts.spec.ts
+++ b/tests/receipts.spec.ts
@@ -1,22 +1,33 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import { getFulfilledResponse, isValidDate } from '../utils';
 
-test("[E2E-ARC-9] Come Cittadino voglio accedere alla pagina di dettaglio di una ricevuta in modo da poter consultare tutte le informazioni disponibili", async ({ page }) => {
-	await page.goto('/pagamenti/');
-  await expect(page).toHaveURL('/pagamenti/')
+test.describe.configure({ mode: 'serial' });
 
+let page: Page;
+
+test.beforeAll(async ({ browser }) => { page = await browser.newPage(); });
+test.afterAll(async () => { await page.close(); });
+
+let transactionId;
+
+test("[E2E-ARC-9] Come Cittadino voglio accedere alla pagina di dettaglio di una ricevuta in modo da poter consultare tutte le informazioni disponibili", async () => {
+  await page.goto('/pagamenti/');
+  await expect(page).toHaveURL('/pagamenti/');
+  
   // waiting for the API call
   const listResponseBody = await getFulfilledResponse(page, 'arc/v1/transactions');
 
   // saving info of the first item
   const listItem = listResponseBody.transactions[0];
 
+  transactionId = listItem.transactionId;
+
   // click on first row item
   page.locator("table[aria-label='Storico table'] > tbody > tr").nth(0).click();
-  await expect(page).toHaveURL(`/pagamenti/transactions/${listItem.transactionId}`);
+  await expect(page).toHaveURL(`/pagamenti/transactions/${transactionId}`);
 
   // waiting for the API call
-  const { infoTransaction: transaction, carts } = await getFulfilledResponse(page, `arc/v1/transactions/${listItem.transactionId}`);
+  const { infoTransaction: transaction, carts } = await getFulfilledResponse(page, `arc/v1/transactions/${transactionId}`);
 
   // DATA CHECKS
   expect(listItem.transactionId === transaction.transactionId).toBeTruthy();
@@ -44,5 +55,14 @@ test("[E2E-ARC-9] Come Cittadino voglio accedere alla pagina di dettaglio di una
   // transactionId
   const transactionIdSubstring = transaction.transactionId.substring(0,7)
   await expect(page.getByText(new RegExp(`${transactionIdSubstring}`))).toBeVisible();
-
+});
+  
+test("[E2E-ARC-10] Come Cittadino voglio poter visualizzare il PDF di un avviso per poterlo stampare (eventualmente)", async ({ browserName }) => {
+  // Unfortunately with chromium this assertion doesn't work. I think it's a kind of bug
+  // https://github.com/microsoft/playwright/issues/6342
+  test.skip(browserName === 'chromium');
+  const pagePromise = page.waitForEvent('popup');  
+  await page.getByTestId('receipt-download-btn').click();
+  const newPage = await pagePromise;
+  await expect(newPage).toHaveURL(/blob:http(s)?:\/\/(dev.|uat.)?cittadini.pagopa.it\/([a-z]|[0-9]|-)*/);
 });


### PR DESCRIPTION
### Description
This PR adds a new E2E test about the receipt PDF 
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- Added the '[E2E-ARC-10]' E2E test
- Skipping the test on 'chromium' due to a bug (comment added)
- Treating receipt tests as sequential and sharing context

<!--- Describe your changes in detail -->

### Motivation and context
The goal of this E2E is about avoiding the introduction of bugs which could broke the receipt PDF view
<!--- Why is this change required? What problem does it solve? -->

### Aggregation level

<!--- Did you write a single reusable test case, or a full test suite?  -->

- [x] Test case
- [ ] Test suite

### Type of changes

- [x] Add new test case/suite
- [x] Modify existing test case/suite

### Test Results

- [x] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Did you update secrets accordingly?

- [ ] Yes
  - [ ] `.pu_ux_secrets_template.yaml`
  - [ ] Pipelines' secure file
  - [ ] Confluence
- [x] Not needed
- [ ] No (_please provide further information_)

### Did you update dependencies accordingly?

Run:

- `npm install 'package'`

and check for changes.

- [ ] Yes
  - [ ] `node_modules`
- [x] Not needed
- [ ] No (_please provide further information_)

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->