### PR TITLE
feat: [P4PU-555] payment notice list page, on error E2E test

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,4 +1,0 @@
-BASE_URL=https://dev.cittadini.pagopa.it/
-ENVIRONMENT=LOCAL
-USERNAME=
-PASSWORD=

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ node_modules/
 /blob-report/
 /playwright/.cache/
 
-.env.local
+.env.*
 .env
 auth/
 


### PR DESCRIPTION
### Description
Added an E2E test to verify that, after an error has occurred trying to get the payment notice list, the error UI is displayed and the retry button work correctly
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- Added a test ([E2E-ARC-5B]) to the file payment-notices.spec.ts

<!--- Describe your changes in detail -->

### Motivation and context
The goal of this E2E is to make sure errors are handled correctly

<!--- Why is this change required? What problem does it solve? -->

### Aggregation level

<!--- Did you write a single reusable test case, or a full test suite?  -->

- [x] Test case
- [ ] Test suite

### Type of changes

- [x] Add new test case/suite
- [ ] Modify existing test case/suite

### Test Results

- [x] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Did you update secrets accordingly?

- [ ] Yes
  - [ ] `.pu_ux_secrets_template.yaml`
  - [ ] Pipelines' secure file
  - [ ] Confluence
- [x] Not needed
- [ ] No (_please provide further information_)

### Did you update dependencies accordingly?

Run:

- `npm install 'package'`

and check for changes.

- [ ] Yes
  - [ ] `node_modules`
- [ ] Not needed
- [ ] No (_please provide further information_)

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->