### PR TITLE
feat: [P4PU-558] Receipt error toast testing.

### DIFF
--- a/tests/receipts-for-user-error.spec.ts
+++ b/tests/receipts-for-user-error.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test';
 test('test if the error page is shown correctly to the user when an error occurs', async ({
   page
 }) => {
-  await page.route('*/**/arc/v1/transactions*', async (route) => {
+  await page.route('*/**/arc/v1/notices*', async (route) => {
     await route.fulfill({
       status: 500,
       contentType: 'application/json'

--- a/tests/receipts.spec.ts
+++ b/tests/receipts.spec.ts
@@ -78,6 +78,8 @@ test('[E2E-ARC-10] Come Cittadino voglio poter visualizzare il PDF di un avviso 
   );
 });
 
+
+
 test('[E2E-ARC-9B] Come Cittadino voglio accedere alla pagina di dettaglio di una ricevuta in modo da poter consultare tutte le informazioni disponibili, ma si verifica un errore.', async () => {
   await page.route('*/**/arc/v1/transactions/*', (route) => {
     route.abort();
@@ -86,6 +88,18 @@ test('[E2E-ARC-9B] Come Cittadino voglio accedere alla pagina di dettaglio di un
   await page.reload();
   await expect(page).toHaveURL(`/pagamenti/transactions/${eventId}`);
   await expect(page.getByText(errorMessage)).toBeVisible({ timeout: 20000 });
+});
+
+test('[E2E-ARC-10B] Come Cittadino voglio poter visualizzare il PDF di un avviso per poterlo stampare (eventualmente), ma si verifica un errore.', async () => {
+  await page.route('*/**/arc/v1/transactions/**/receipt*', async (route) => {
+    await route.fulfill({
+      status: 500,
+      contentType: 'application/json'
+    });
+  });
+  await page.getByTestId('receipt-download-btn').click();
+
+  await expect(page.getByRole('alert')).toBeVisible();
 });
 
 test(`[E2E-ARC-5C] Come Cittadino voglio accedere alla lista degli avvisi da pagare in modo da poter avere una visione sintetica e d’insieme, non ottengo alcun errore, ma non ho avvisi associati.`, async () => {


### PR DESCRIPTION
### Description
This PR adds a test for the toast notification the user gets when an error occurs when trying to fetch a receipt
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Aggregation level

<!--- Did you write a single reusable test case, or a full test suite?  -->

- [ ] Test case
- [ ] Test suite

### Type of changes

- [ ] Add new test case/suite
- [ ] Modify existing test case/suite

### Test Results

- [ ] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Did you update secrets accordingly?

- [ ] Yes
  - [ ] `.pu_ux_secrets_template.yaml`
  - [ ] Pipelines' secure file
  - [ ] Confluence
- [ ] Not needed
- [ ] No (_please provide further information_)

### Did you update dependencies accordingly?

Run:

- `npm install 'package'`

and check for changes.

- [ ] Yes
  - [ ] `node_modules`
- [ ] Not needed
- [ ] No (_please provide further information_)

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->