### PR TITLE
feat: smarter logic test

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,3 @@
 BASE_URL=https://dev.cittadini.pagopa.it
-# LOCAL | DEV | UAT
-ENVIRONMENT=LOCAL 
 USERNAME=
 PASSWORD=

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ The table below describes all the Environment variables needed by the applicatio
 | Variable name | Description              | type                  |
 | ------------- | ------------------------ | --------------------- |
 | BASE_URL      | the target site          | url                   |
-| ENVIRONMENT   | environment of execution | "LOCAL", "DEV", "UAT" |
 | USERNAME      | Username to access with  | string                |
 | PASSWORD      | Password for the user    | string                |
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,7 +4,7 @@ import path from 'path';
 
 dotenv.config({ path: path.resolve(__dirname, '.env') });
 
-console.log(`Running tests on: ${process.env.BASE_URL}; environment: ${process.env.ENVIRONMENT}`);
+console.log(`Running tests on: ${process.env.BASE_URL}`);
 
 /**
  * See https://playwright.dev/docs/test-configuration.

--- a/tests/login.setup.ts
+++ b/tests/login.setup.ts
@@ -10,7 +10,9 @@ const executeLoginSteps = async (page: Page) => {
   expect(username).toBeTruthy();
   expect(password).toBeTruthy();
 
-  if (!(username && password)) { throw new Error('Setup has failed, missing username and/or password!');}
+  if (!(username && password)) {
+    throw new Error('Setup has failed, missing username and/or password!');
+  }
   await page.goto('/');
   await page.goto('/pagamenti/login');
   await page.getByLabel('Accedi').click();
@@ -24,7 +26,7 @@ const executeLoginSteps = async (page: Page) => {
   await page.getByLabel('Password').fill(password);
   await page.getByRole('button', { name: 'Entra con SPID' }).click();
   await page.getByRole('button', { name: 'Conferma' }).click();
-}
+};
 
 const saveState = async (page: Page) => {
   // this means we are logged in on the main dashboard page
@@ -33,7 +35,7 @@ const saveState = async (page: Page) => {
   expect(accessToken).toBeTruthy();
   // storing user contex
   await page.context().storageState({ path: authFile });
-}
+};
 
 setup(
   "[E2E-ARC-1] Come Cittadino voglio autenticarmi nell' Area Riservata Cittadino per poter usufruire dei servizi offerti",
@@ -53,10 +55,11 @@ setup(
           const { search } = new URL(request.url());
           await route.abort();
           await page.goto(`/pagamenti/auth-callback${search}`);
-          return
-        } 
+          return;
+        }
         route.continue();
-        }, { times: 1 }
+      },
+      { times: 1 }
     );
 
     await executeLoginSteps(page);

--- a/tests/login.setup.ts
+++ b/tests/login.setup.ts
@@ -50,22 +50,15 @@ setup(
 
     await page.route(
       '**/token/oneidentity*',
-      async (route, request) => {
+      async (_route, request) => {
         const url = new URL(page.url())
-        if( url.hostname.includes('cittadini.pagopa.it')) {
           const { search } = new URL(request.url());
           await page.goto(`/pagamenti/auth-callback${search}`);
-        } else {
-          await route.continue();
-        }
-      }
+      }, { times: 1 }
     );
 
     await executeLoginSteps(page);
-    // waitForTimeout should not be used in production, Tests that wait for time are inherently flaky.
-    // unfortunately this is the only way to make this test works properly, actually
-    // we should find a more solid solution
-    await page.waitForTimeout(3*1000);
+    await page.unrouteAll({ behavior: 'ignoreErrors' })
     await saveState(page);
   }
 );

--- a/tests/login.setup.ts
+++ b/tests/login.setup.ts
@@ -13,7 +13,6 @@ const executeLoginSteps = async (page: Page) => {
   if (!(username && password)) { throw new Error('Setup has failed, missing username and/or password!');}
   await page.goto('/');
   await page.goto('/pagamenti/login');
-  await page.getByRole('button', { name: 'Accetta tutti' }).click();
   await page.getByLabel('Accedi').click();
   await page.getByRole('button', { name: 'Entra con SPID' }).click();
   await page.getByTestId('idp-button-https://demo.spid.gov.it').click();

--- a/tests/login.setup.ts
+++ b/tests/login.setup.ts
@@ -4,40 +4,85 @@ import path from 'path';
 
 const authFile = path.join(__dirname, `../${userPath}`);
 
+const commonStep = async (page) => {
+  const username = process.env?.USERNAME;
+  const password = process.env?.PASSWORD;
+  expect(username).toBeTruthy();
+  expect(password).toBeTruthy();
+
+  if (!(username && password)) { throw new Error('Setup has failed, missing username and/or password!');}
+  await page.goto('/');
+  await page.goto('/pagamenti/login');
+  await page.getByRole('button', { name: 'Accetta tutti' }).click();
+  await page.getByLabel('Accedi').click();
+  await page.getByRole('button', { name: 'Entra con SPID' }).click();
+  await page.getByTestId('idp-button-https://demo.spid.gov.it').click();
+  await page.waitForURL('**/start');
+  await expect(page.locator('#username')).toBeVisible({ timeout: 20000 });
+  await page.locator('#username').click();
+  await page.locator('#username').fill(username);
+  await page.locator('#username').press('Tab');
+  await page.getByLabel('Password').fill(password);
+  await page.getByRole('button', { name: 'Entra con SPID' }).click();
+  await page.getByRole('button', { name: 'Conferma' }).click();
+  await page.waitForURL('/pagamenti/auth-callback*');
+}
+
+// LOCALHOST
+// Questo setup è da utilizzarsi quando i test vengono lanciati puntando ad un'abiente locale
+// è necessario avere uno step dedicato e differente rispetta all'ambiente dev o uat
+// perchè il servizio esterno di autenticazione oneIdentity ridirigge a sempre ad uno specifico ambiente (dev o uat)
+// e non prevede un ritorno su locahost. Per questo motivo la sezione page.route provedde and intercettare il ritorno,
+// ad abortire la chiamata per l'ottenimento del token (pena l'ivalidamento) e redirigere correttamente su localhost
+// così che al termine del flusso, venga prodotto un file auth/user.json per l'ambiente corretto (localhost)
 setup(
-  "[E2E-ARC-1]Come Cittadino voglio autenticarmi nell' Area Riservata Cittadino per poter usufruire dei servizi offerti",
+  "[E2E-ARC-1] local: Come Cittadino voglio autenticarmi nell' Area Riservata Cittadino per poter usufruire dei servizi offerti",
   async ({ page }) => {
-    setup.skip(
-      await skipAuth(),
+    setup.skip(await skipAuth() ? true : process.env.BASE_URL?.includes('cittadini') as boolean,
       'Non è necessario autenticarsi più volte, sopratutto durante le fasi di sviluppo e debug'
     );
 
-    const username = process.env?.USERNAME;
-    const password = process.env?.PASSWORD;
-    expect(username).toBeTruthy();
-    expect(password).toBeTruthy();
+    await page.route(
+      '**/token/oneidentity*',
+      async (route, request) => {
+        console.log('fire')
+        const url = new URL(page.url())
+        if( url.hostname.includes('cittadini.pagopa.it')) {
+          await route.abort();
+          const { search } = new URL(request.url());
+          page.goto(`http://localhost:1234/pagamenti/auth-callback${search}`);
+        } else {
+          await route.continue();
+        }
+      }
+    );
 
-    if (username && password) {
-      await page.goto('/');
-      await page.goto('/pagamenti/login');
-      await page.getByLabel('Accedi').click();
-      await page.getByRole('button', { name: 'Entra con SPID' }).click();
-      await page.getByLabel('demo', { exact: true }).click();
-      await page.waitForURL('**/start');
-      await expect(page.locator('#username')).toBeVisible({ timeout: 20000 });
-      await page.locator('#username').click();
-      await page.locator('#username').fill(username);
-      await page.locator('#username').press('Tab');
-      await page.getByLabel('Password').fill(password);
-      await page.getByRole('button', { name: 'Entra con SPID' }).click();
-      await page.getByRole('button', { name: 'Conferma' }).click();
-      await page.waitForURL('**/pagamenti/');
-      await expect(page.getByLabel('app.dashboard.greeting')).toBeVisible();
-      const accessToken = await page.evaluate(() => localStorage.getItem('accessToken'));
-      expect(accessToken).toBeTruthy();
+    await commonStep(page);
 
-      // storing user contex
-      await page.context().storageState({ path: authFile });
-    }
+    //await page.waitForURL('/pagamenti/auth-callback*');
+    const accessToken = await page.evaluate(() => localStorage.getItem('accessToken'));
+    expect(accessToken).toBeTruthy();
+    // storing user contex
+    await page.context().storageState({ path: authFile });
+  }
+);
+
+// DEV, UAT
+setup(
+  "[E2E-ARC-1] env Come Cittadino voglio autenticarmi nell' Area Riservata Cittadino per poter usufruire dei servizi offerti",
+  async ({ page }) => {
+    setup.skip(
+      await skipAuth() ? true : process.env.BASE_URL?.includes('localhost') as boolean,
+      'Non è necessario autenticarsi più volte, sopratutto durante le fasi di sviluppo e debug'
+    );
+
+    await commonStep(page);
+
+    await page.waitForURL('**/pagamenti/');
+    await expect(page.getByLabel('app.dashboard.greeting')).toBeVisible();
+    const accessToken = await page.evaluate(() => localStorage.getItem('accessToken'));
+    expect(accessToken).toBeTruthy();
+    // storing user contex
+    await page.context().storageState({ path: authFile });
   }
 );

--- a/utils.ts
+++ b/utils.ts
@@ -2,12 +2,7 @@ import fs from 'fs';
 import { Page } from '@playwright/test';
 import { jwtDecode } from 'jwt-decode';
 
-/** 'LOCAL' | 'DEV' | 'UAT' */
-export type ENVIRONMENT = 'LOCAL' | 'DEV' | 'UAT';
-export const ENVIRONMENTDEFAULT = 'LOCAL';
 export const userPath = 'auth/user.json';
-
-const env: ENVIRONMENT = (process.env.ENVIRONMENT as ENVIRONMENT) || ENVIRONMENTDEFAULT;
 
 // Helper function to wait for the fulfilled response
 export async function getFulfilledResponse(page: Page, path: string) {
@@ -26,10 +21,10 @@ export function isValidDate(d: string) {
   return date.getTime() === date.getTime();
 }
 
-// Auth phase can be skipped when the ENVIRONMENT === 'LOCAL' and a user.json file exists and the token is still valid
+// Auth phase can be skipped when an user.json file exists and the token is still valid
 export const skipAuth = async (): Promise<boolean> =>
   new Promise((resolve) => {
-    if (fs.existsSync(userPath) && env === 'LOCAL') {
+    if (fs.existsSync(userPath)) {
       fs.readFile(userPath, 'utf8', (err, jsonString) => {
         if (err) {
           console.log('File read failed:', err);


### PR DESCRIPTION
### Description
With this fix the E2E tests can be launched pointing to a local server without any issue related to the user authentication

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
- removing useless environment variable (ENVIRONMENT)
- storing auth info accordingly the fe domain

<!--- Describe your changes in detail -->

### Motivation and context
The OneIdentity service doesn't provide for a return to localhost when the process ends and by consequence the E2E tests can't be launched pointing at localhost without having issue with the authentication.

<!--- Why is this change required? What problem does it solve? -->

### Aggregation level

<!--- Did you write a single reusable test case, or a full test suite?  -->

- [x] Test case
- [ ] Test suite

### Type of changes

- [ ] Add new test case/suite
- [x] Modify existing test case/suite

### Test Results

- [x] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Did you update secrets accordingly?

- [ ] Yes
  - [ ] `.pu_ux_secrets_template.yaml`
  - [ ] Pipelines' secure file
  - [ ] Confluence
- [x] Not needed
- [ ] No (_please provide further information_)

### Did you update dependencies accordingly?

Run:

- `npm install 'package'`

and check for changes.

- [ ] Yes
  - [ ] `node_modules`
- [x] Not needed
- [ ] No (_please provide further information_)

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->