### PR TITLE
fix: [P4PU-692] Updating a wrong testId and waitForTimeout removed

### DIFF
--- a/tests/payment-notices.spec.ts
+++ b/tests/payment-notices.spec.ts
@@ -110,17 +110,20 @@ test(`[E2E-ARC-5B] Come Cittadino voglio accedere alla lista degli avvisi da pag
   const OPTIN = await page.evaluate(() => sessionStorage.getItem('OPTIN'));
   expect(OPTIN).toBeTruthy();
 
-  // waiting for retries ending
-  await page.waitForTimeout(1000 * 10);
-  expect(page.getByTestId('app.transactions.error')).toBeVisible();
+  // timeout extending, waiting for retries ending on routes abort
+  await expect(page.getByTestId('app.paymentNotice.error.description')).toBeVisible({
+    timeout: 1000 * 10
+  });
 
   // clearing abort
   await page.unroute('**/arc/v1/payment-notices');
   await page.getByTestId('app.paymentNotice.error.button').click();
-  await page.waitForTimeout(1000 * 10);
 
   // wait for the list of payment notices assuming that by now the API works
-  await expect(page.locator('#payment-notices-list')).toBeVisible();
+  // timeout extended to wait for the fake loading
+  await expect(page.locator('#payment-notices-list')).toBeVisible({
+    timeout: 1000 * 10
+  });
   const optionsListItemsCount = await page.getByTestId('payment-notices-item').count();
   expect(optionsListItemsCount).toBeGreaterThan(0);
 });


### PR DESCRIPTION
### Description

Updating a wrong testId and waitForTimeout removed

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- app.transactions.error → app.paymentNotice.error.description
- waitForTimeout removed

<!--- Describe your changes in detail -->

### Motivation and context
E2E test '[E2E-ARC-5B] Come Cittadino voglio accedere alla lista degli avvisi da pagare, ma si verifca un errore' was failing





<!--- Why is this change required? What problem does it solve? -->

### Aggregation level

<!--- Did you write a single reusable test case, or a full test suite?  -->

- [x] Test case
- [ ] Test suite

### Type of changes

- [ ] Add new test case/suite
- [x] Modify existing test case/suite

### Test Results

- [x] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Did you update secrets accordingly?

- [ ] Yes
  - [ ] `.pu_ux_secrets_template.yaml`
  - [ ] Pipelines' secure file
  - [ ] Confluence
- [x] Not needed
- [ ] No (_please provide further information_)

### Did you update dependencies accordingly?

Run:

- `npm install 'package'`

and check for changes.

- [ ] Yes
  - [ ] `node_modules`
- [x] Not needed
- [ ] No (_please provide further information_)

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->