### PR TITLE
fix: [P4PU-676] deleted RRN check from paid notice detail (as per design)

### DIFF
--- a/tests/receipts.spec.ts
+++ b/tests/receipts.spec.ts
@@ -59,8 +59,6 @@ test('[E2E-ARC-9] Come Cittadino voglio accedere alla pagina di dettaglio di una
   expect(isValidDate(notice.noticeDate)).toBeTruthy();
   // psp name
   await expect(page.locator('#transaction-detail-psp')).toHaveText(notice.pspName);
-  // rrn
-  await expect(page.locator('#transaction-detail-rrn')).toHaveText(notice.rrn);
   // eventId
   const eventIdSubstring =
     notice.eventId.length > 20 ? notice.eventId.substring(0, 20) + '…' : notice.eventId;


### PR DESCRIPTION
### Description
deleted RRN check from paid notice detail  (as per design)
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- tests/receipts.spec.ts test updated

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
RRN data on paid notice detail is not anymore required and needs all is related to it have to be deleted from FE and E2E test
### Aggregation level

<!--- Did you write a single reusable test case, or a full test suite?  -->

- [x] Test case
- [ ] Test suite

### Type of changes

- [ ] Add new test case/suite
- [x] Modify existing test case/suite

### Test Results

- [x] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Did you update secrets accordingly?

- [ ] Yes
  - [ ] `.pu_ux_secrets_template.yaml`
  - [ ] Pipelines' secure file
  - [ ] Confluence
- [x] Not needed
- [ ] No (_please provide further information_)

### Did you update dependencies accordingly?

Run:

- `npm install 'package'`

and check for changes.

- [ ] Yes
  - [ ] `node_modules`
- [x] Not needed
- [ ] No (_please provide further information_)

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->