### PR TITLE
fix: [P4PU-783] fixing assistance E2E test

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -28,7 +28,6 @@ export default defineConfig({
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: process.env.BASE_URL,
-
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry'
   },

--- a/tests/assistance.spec.ts
+++ b/tests/assistance.spec.ts
@@ -3,7 +3,6 @@ import { test, expect } from '@playwright/test';
 test('[E2E-ARC-11] Come Cittadino autenticato voglio accedere alla sezione di Assistenza in modo da aprire una segnalazione', async ({
   page
 }) => {
-  const newTicketURL = 'https://pagamenti.assistenza.pagopa.it/hc/it-it/requests/new';
   await page.goto('/pagamenti/');
   await expect(page).toHaveURL('/pagamenti/');
   const pagePromise = page.waitForEvent('popup');
@@ -14,5 +13,5 @@ test('[E2E-ARC-11] Come Cittadino autenticato voglio accedere alla sezione di As
   await newPage.getByTestId('assistance-confirm-email').fill(userEmail);
   await newPage.getByTestId('assistance-confirm-email').dispatchEvent('change');
   await newPage.getByTestId('assistance-confirm-button').click();
-  await expect(newPage).toHaveURL(newTicketURL, { timeout: 10000 });
+  await newPage.waitForURL('**/requests/new', { timeout: 1000 * 10 });
 });

--- a/tests/assistance.spec.ts
+++ b/tests/assistance.spec.ts
@@ -8,10 +8,10 @@ test('[E2E-ARC-11] Come Cittadino autenticato voglio accedere alla sezione di As
   const pagePromise = page.waitForEvent('popup');
   await page.getByRole('button', { name: 'Assistenza' }).click();
   const newPage = await pagePromise;
-  await expect(newPage.getByTestId('confirm-email')).not.toHaveValue('', { timeout: 2000 });
+  await expect(newPage.getByTestId('confirm-email')).not.toHaveValue('');
   const userEmail = await newPage.getByTestId('confirm-email').inputValue();
   await newPage.getByTestId('assistance-confirm-email').fill(userEmail);
   await newPage.getByTestId('assistance-confirm-email').dispatchEvent('change');
   await newPage.getByTestId('assistance-confirm-button').click();
-  await newPage.waitForURL('**/requests/new', { timeout: 1000 * 10 });
+  await newPage.waitForURL('**/requests/new');
 });

--- a/tests/receipts.spec.ts
+++ b/tests/receipts.spec.ts
@@ -75,7 +75,7 @@ test('[E2E-ARC-10] Come Cittadino voglio poter visualizzare il PDF di un avviso 
   await page.getByTestId('receipt-download-btn').click();
   const newPage = await pagePromise;
   await expect(newPage).toHaveURL(
-    /blob:http(s)?:\/\/(dev.|uat.)?cittadini.pagopa.it\/([a-z]|[0-9]|-)*/
+    /blob:http(s)?:\/\/((dev.|uat.)?cittadini.pagopa.it|localhost:1234)\/([a-z]|[0-9]|-)*/
   );
 });
 


### PR DESCRIPTION
### Description
This change fixs a problem which was causing a test failure
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- assistance.spec.ts updated
- receipts.spec.ts updated (to make it works also running test locally)

<!--- Describe your changes in detail -->

### Motivation and context
The assistance URL has changed. As consequence the assertion on that isn't valid anymore.

<!--- Why is this change required? What problem does it solve? -->

### Aggregation level

<!--- Did you write a single reusable test case, or a full test suite?  -->

- [x] Test case
- [ ] Test suite

### Type of changes

- [ ] Add new test case/suite
- [x] Modify existing test case/suite

### Test Results

- [x] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Did you update secrets accordingly?

- [ ] Yes
  - [ ] `.pu_ux_secrets_template.yaml`
  - [ ] Pipelines' secure file
  - [ ] Confluence
- [x] Not needed
- [ ] No (_please provide further information_)

### Did you update dependencies accordingly?

Run:

- `npm install 'package'`

and check for changes.

- [ ] Yes
  - [ ] `node_modules`
- [x] Not needed
- [ ] No (_please provide further information_)

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->