### PR TITLE
feat: [P4PU-758] routes nemad

### DIFF
--- a/tests/login.setup.ts
+++ b/tests/login.setup.ts
@@ -62,7 +62,7 @@ setup(
           searchParam = search;
           // Abort the current hit
           await route.abort();
-          await page.waitForURL('**/errore*');
+          await page.waitForURL('**/courtesy*');
           // Redirect to the local auth-callback
           await page.goto(`/pagamenti/auth-callback${searchParam}`);
         }

--- a/tests/login.setup.ts
+++ b/tests/login.setup.ts
@@ -62,7 +62,7 @@ setup(
           searchParam = search;
           // Abort the current hit
           await route.abort();
-          await page.waitForURL('**/courtesy*');
+          await page.waitForURL('**/errore*');
           // Redirect to the local auth-callback
           await page.goto(`/pagamenti/auth-callback${searchParam}`);
         }

--- a/tests/payment-notices.spec.ts
+++ b/tests/payment-notices.spec.ts
@@ -28,8 +28,8 @@ test("[E2E-ARC-4] Come Cittadino autenticato voglio cliccare sul pulsante 'Paga 
 test(`Avvisi e pagamento`, async () => {
   const selectedItem =
     await test.step(`[E2E-ARC-5] Come Cittadino voglio accedere alla lista degli avvisi da pagare`, async () => {
-      await page.goto('/pagamenti/payment-notices/');
-      await expect(page).toHaveURL('/pagamenti/payment-notices/');
+      await page.goto('/pagamenti/avvisi/');
+      await expect(page).toHaveURL('/pagamenti/avvisi/');
       await expect(page.locator('#searchButtonPaymentNotices')).toBeVisible();
       await page.locator('#searchButtonPaymentNotices').click();
 
@@ -58,7 +58,7 @@ test(`Avvisi e pagamento`, async () => {
       await expect(listFirstItem.getByTestId('payment-notices-item-cta')).toBeVisible();
       await listFirstItem.getByTestId('payment-notices-item-cta').click();
       await expect(page).toHaveURL(
-        `/pagamenti/payment-notices/${selectedItem.iupd}/${selectedItem.paTaxCode}`
+        `/pagamenti/avvisi/${selectedItem.iupd}/${selectedItem.paTaxCode}`
       );
       return selectedItem;
     });
@@ -128,8 +128,8 @@ test(`[E2E-ARC-5B] Come Cittadino voglio accedere alla lista degli avvisi da pag
   // causing a error when requesting payment notices items
   await page.route('**/arc/v1/payment-notices', (route) => route.abort());
 
-  await page.goto('/pagamenti/payment-notices/');
-  await expect(page).toHaveURL('/pagamenti/payment-notices/');
+  await page.goto('/pagamenti/avvisi/');
+  await expect(page).toHaveURL('/pagamenti/avvisi/');
 
   // test if session storage var is filled
   const OPTIN = await page.evaluate(() => sessionStorage.getItem('OPTIN'));
@@ -164,6 +164,6 @@ test(`[E2E-ARC-5C] Come Cittadino voglio accedere alla lista degli avvisi da pag
   // reload
   page.reload();
   // test
-  await expect(page).toHaveURL('/pagamenti/payment-notices/');
+  await expect(page).toHaveURL('/pagamenti/avvisi/');
   await expect(page.getByTestId('app.paymentNotice.empty')).toBeVisible({ timeout: 10000 });
 });

--- a/tests/receipts.spec.ts
+++ b/tests/receipts.spec.ts
@@ -29,7 +29,7 @@ test('[E2E-ARC-9] Come Cittadino voglio accedere alla pagina di dettaglio di una
 
   // click on first row item
   page.getByTestId('transaction-details-button').first().click();
-  await expect(page).toHaveURL(`/pagamenti/transactions/${eventId}`);
+  await expect(page).toHaveURL(`/pagamenti/ricevute/${eventId}`);
 
   // waiting for the API call
   const { infoNotice: notice, carts } = await getFulfilledResponse(
@@ -96,6 +96,6 @@ test('[E2E-ARC-9B] Come Cittadino voglio accedere alla pagina di dettaglio di un
     route.abort();
   });
   await page.reload();
-  await expect(page).toHaveURL(`/pagamenti/transactions/${eventId}`);
+  await expect(page).toHaveURL(`/pagamenti/ricevute/${eventId}`);
   await expect(page.locator('#transaction-detail-error')).toBeVisible({ timeout: 20000 });
 });

--- a/tests/user.spec.ts
+++ b/tests/user.spec.ts
@@ -18,7 +18,7 @@ test("[E2E-ARC-2] Come Cittadino autenticato voglio accedere alla sezione 'I mie
   await page.getByRole('button').getByText(`${user.name} ${user.familyName}`).click();
   await page.getByText('I tuoi dati').click();
 
-  page.waitForURL('**/user');
+  page.waitForURL('**/profilo');
 
   await expect(page.getByTestId('app.user.title')).toBeVisible();
   await expect(page.getByTestId('app.user.info.name.value')).toContainText(user.name);

--- a/tests/user.spec.ts
+++ b/tests/user.spec.ts
@@ -40,7 +40,7 @@ test("[E2E-ARC-3] Come Cittadino voglio 'sloggarmi' dall'applicativo", async ({ 
   await expect(page.getByLabel('party-menu-button')).toBeVisible();
   await page.getByLabel('party-menu-button').click();
   await page.getByRole('menuitem').getByText('Esci').click();
-  await page.waitForURL('**/login');
+  await page.waitForURL('**/accesso');
 
   const accessToken = await page.evaluate(() => localStorage.getItem('accessToken'));
   expect(accessToken).toBeNull();


### PR DESCRIPTION
### Description

This PR updates all "expect"  and "goto" so that the url pages reflects the new routes name convention

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- 'payment-notices' -> 'avvisi'
- 'transactions' -> 'ricevute'
- 'login' -> 'accesso'
- 'user' -> 'profilo'

<!--- Describe your changes in detail -->

### Motivation and context

This is required because the URLs were renamed
<!--- Why is this change required? What problem does it solve? -->

### Aggregation level

<!--- Did you write a single reusable test case, or a full test suite?  -->

- [x] Test case
- [ ] Test suite

### Type of changes

- [ ] Add new test case/suite
- [x] Modify existing test case/suite

### Test Results

- [x] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Did you update secrets accordingly?

- [ ] Yes
  - [ ] `.pu_ux_secrets_template.yaml`
  - [ ] Pipelines' secure file
  - [ ] Confluence
- [x] Not needed
- [ ] No (_please provide further information_)

### Did you update dependencies accordingly?

Run:

- `npm install 'package'`

and check for changes.

- [ ] Yes
  - [ ] `node_modules`
- [x] Not needed
- [ ] No (_please provide further information_)

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->