### PR TITLE
fix: [P4PU-888] remove unnecessary drawer close action in payment notices test

### DIFF
--- a/tests/payment-notices.spec.ts
+++ b/tests/payment-notices.spec.ts
@@ -124,9 +124,6 @@ test(`[E2E-ARC-5B] Come Cittadino voglio accedere alla lista degli avvisi da pag
   await page.goto('/pagamenti/avvisi/');
   await expect(page).toHaveURL('/pagamenti/avvisi/');
 
-  // close the drawer
-  await page.getByTestId('CloseIcon').click();
-
   // test if session storage var is filled
   const OPTIN = await page.evaluate(() => sessionStorage.getItem('OPTIN'));
   expect(OPTIN).toBeTruthy();


### PR DESCRIPTION
### Description

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR as title suggests fix a test, deleting an unnecessary step

### List of changes
- test with label 'E2E-ARC-5B' updated

<!--- Describe your changes in detail -->

### Motivation and context
This fix is required because the relative E2E test was failing
<!--- Why is this change required? What problem does it solve? -->

### Aggregation level

<!--- Did you write a single reusable test case, or a full test suite?  -->

- [x] Test case
- [ ] Test suite

### Type of changes

- [ ] Add new test case/suite
- [x] Modify existing test case/suite

### Test Results

- [x] Success
- [ ] Failure
- [ ] Poor performance
- [ ] Good performance

### Did you update secrets accordingly?

- [ ] Yes
  - [ ] `.pu_ux_secrets_template.yaml`
  - [ ] Pipelines' secure file
  - [ ] Confluence
- [x] Not needed
- [ ] No (_please provide further information_)

### Did you update dependencies accordingly?

Run:

- `npm install 'package'`

and check for changes.

- [ ] Yes
  - [ ] `node_modules`
- [x] Not needed
- [ ] No (_please provide further information_)

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->